### PR TITLE
bug fix

### DIFF
--- a/DDNS.go
+++ b/DDNS.go
@@ -303,7 +303,7 @@ func RunOverride(GlobalDevice Device.Device, parameters []DDNS.Parameters) error
 	log.Info("-O is set, override the ip address")
 	var errCount uint16
 
-	i := 0 // to avoid out of bound: add if not error, if remove from the slice, do not add
+	// i := 0 // to avoid out of bound: add if not error, if remove from the slice, do not add
 	for _, parameter := range parameters {
 		// skip the device parameter
 		if parameter.GetName() != Device.ServiceName {
@@ -317,20 +317,18 @@ func RunOverride(GlobalDevice Device.Device, parameters []DDNS.Parameters) error
 				if !d.IsDeviceSet() {
 					err := set(GlobalDevice, parameter)
 					if err != nil {
-						log.Errorf("error setting ip address: %s, skip service:%s", err.Error(), parameter.GetName())
+						log.Errorf("error setting ip address: %s, skip overriding service:%s", err.Error(), parameter.GetName())
 						errCount++
-						parameters = append(parameters[:i], parameters[i+1:]...)
+
 						continue
 					}
-					i++
 					log.Warnf("Devices of %s is not set, use default value %s", parameter.GetName(), parameter.(DDNS.DeviceOverridable).GetIP())
 					continue // skip
 				}
 
 				if !d.IsTypeSet() {
-					i++
 					errCount++
-					parameters = append(parameters[:i], parameters[i+1:]...)
+
 					log.Errorf("error setting ip address: unknown type, skip service:%s", parameter.GetName())
 					continue
 				}
@@ -340,11 +338,10 @@ func RunOverride(GlobalDevice Device.Device, parameters []DDNS.Parameters) error
 				ips, err := Net.GetIpByType(tempDeviceName, uint8(TypeInt))
 				if err != nil {
 					errCount++
-					parameters = append(parameters[:i], parameters[i+1:]...)
+
 					log.Errorf("error getting ip address: %s, skip service:%s", err.Error(), parameter.GetName())
 					continue
 				}
-				i++
 
 				log.Infof("override %s with %s", parameter.GetName(), ips[0])
 				parameter.(DDNS.DeviceOverridable).SetValue(ips[0])
@@ -353,15 +350,12 @@ func RunOverride(GlobalDevice Device.Device, parameters []DDNS.Parameters) error
 				err := set(GlobalDevice, parameter)
 				if err != nil {
 					errCount++
-					parameters = append(parameters[:i], parameters[i+1:]...)
+
 					continue
 				}
-				i++
 				log.Debugf("Parameter %s is not DeviceOverridable, use default value %s", parameter.GetName(), parameter.(DDNS.ServiceParameters).GetIP())
 			}
 
-		} else {
-			i++
 		}
 	} // loop ends
 

--- a/DDNS/Config_test.go
+++ b/DDNS/Config_test.go
@@ -118,6 +118,8 @@ func TestConfigStr(t *testing.T) {
 	}
 
 	t.Log(p.ConfigStr().Content)
+
+	t.Log(DefaultConfig.ConfigStr().Content)
 }
 
 func TestLoadProxy(t *testing.T) {
@@ -133,15 +135,13 @@ func TestLoadProxy(t *testing.T) {
 }
 
 func TestProgramConfigGenerateConfiguration(t *testing.T) {
-	u1, _ := url.Parse("https://myip.ipip.net/s")
-	u2, _ := url.Parse("https://speed.neu6.edu.cn/getIP.php")
-	u3, _ := url.Parse("https://ip.3322.net")
+	u1, _ := url.Parse("socks5://localhost:10808")
+	u2, _ := url.Parse("https://localhost:10809")
 
 	p := ProgramConfig{
 		proxy: []*url.URL{
 			u1,
 			u2,
-			u3,
 		},
 		ags: []ApiGenerator{
 			{
@@ -163,7 +163,7 @@ func TestProgramConfigGenerateConfiguration(t *testing.T) {
 		},
 	}
 
-	err := p.generateConfigFile()
+	err := p.GenerateConfigFile()
 	if err != nil {
 		t.Error(err)
 	}

--- a/DDNS/ProgramConfig.go
+++ b/DDNS/ProgramConfig.go
@@ -99,18 +99,20 @@ func (p *ProgramConfig) Setup() {
 
 }
 
-// generateConfigFile generate config file
+var DefaultConfig = ProgramConfig{
+	proxy: nil,
+	ags:   nil,
+}
+
+// GenerateConfigFile generate config file
 // if config file already exists, return error
-func (p *ProgramConfig) generateConfigFile() error {
+func (p *ProgramConfig) GenerateConfigFile() error {
 	location, err := GetProgramConfigLocation()
 	if err != nil {
 		return err
 	}
 
-	stat, _ := os.Stat(location)
-
-	// will not overwrite the config
-	if stat != nil {
+	if IsConfigExist(location) {
 		return errors.New("config file already exists")
 	}
 
@@ -119,6 +121,14 @@ func (p *ProgramConfig) generateConfigFile() error {
 	// }
 
 	return ConfigureWriter(location, os.O_CREATE|os.O_APPEND, p.ConfigStr())
+}
+
+func IsConfigExist(file string) bool {
+	_, err := os.Stat(file)
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 // LoadProgramConfig load program config from file

--- a/DDNS/ServiceConfig.go
+++ b/DDNS/ServiceConfig.go
@@ -238,38 +238,6 @@ func ConfigureReader(Filename string, configs ...ConfigFactory) (ps []Parameters
 	return ps, nil, ReadConfigErrs
 }
 
-// IsConfigureExist check if config file exist
-func IsConfigureExist() bool {
-	_, err := os.Stat(GetConfigureLocation())
-
-	return !errors.Is(err, os.ErrNotExist)
-}
-
-// SaveConfig save parameters to file with flag
-func SaveConfig(FileName string, flag int, parameters ...Parameters) error {
-	var err error
-	n := make(map[string]uint)
-	ConfigStrings := make([]ConfigStr, 0, len(parameters))
-	for _, parameter := range parameters {
-		var no uint
-		if parameter.GetName() == "Device" { // todo refactor do not use hard code "Device"
-			no = 0
-		} else {
-			n[parameter.GetName()]++
-			no = n[parameter.GetName()]
-		}
-		ConStr, err_ := parameter.SaveConfig(no)
-
-		if err_ != nil {
-			err = errors.Join(err, err_)
-		} else {
-			ConfigStrings = append(ConfigStrings, ConStr)
-		}
-	}
-	err = errors.Join(err, ConfigureWriter(FileName, flag, ConfigStrings...))
-	return err
-}
-
 // ConfigHead generate config head, the section name
 // [Name#No]
 // if No == 0, [Name]

--- a/README.md
+++ b/README.md
@@ -109,9 +109,6 @@ GLOBAL OPTIONS:
 * [ ] new feature support multi-device for each service(like Device does)
 * [ ] ? refactor Dnspod.Config.ReadConfig:62
 
-## ISSUES
-
-1. may be bug when deleting element in loop, see main.go:408
 
 ## [![Repography logo](https://images.repography.com/logo.svg)](https://repography.com) Structure
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ GodDns run auto
 ```
 get ip address from api
 ```bash
-GodDns run --api ipify/identMe/others
+GodDns run --api=ipify/identMe/others
 ```
 through proxy
 ```bash
-GodDns run --proxy http://127.0.0.1:10809
-GodDns run --proxy enable
-GodDns run --proxy disable
+GodDns run --proxy=http://127.0.0.1:10809
+GodDns run --proxy=enable
+GodDns run --proxy=disable
 ```
 parallel executing
 ```bash
@@ -106,7 +106,6 @@ GLOBAL OPTIONS:
 
 * [ ] add more service
 * [ ] to fix RunPerTime at main.go:664
-* [ ] todo refactor do not use hard code "Devices" at DDNS.Config:211
 * [ ] new feature support multi-device for each service(like Device does)
 * [ ] ? refactor Dnspod.Config.ReadConfig:62
 

--- a/Service/Dnspod/Config_test.go
+++ b/Service/Dnspod/Config_test.go
@@ -2,7 +2,6 @@ package Dnspod
 
 import (
 	"GodDns/DDNS"
-	"os"
 	"strings"
 	"testing"
 
@@ -50,14 +49,6 @@ func TestConfig_ReadConfig(t *testing.T) {
 		t.Error(err)
 	}
 	t.Log(config)
-
-}
-
-func TestSave(t *testing.T) {
-	err := DDNS.SaveConfig("test.conf", os.O_CREATE|os.O_APPEND|os.O_WRONLY, &p)
-	if err != nil {
-		t.Error(err)
-	}
 
 }
 

--- a/main.go
+++ b/main.go
@@ -192,18 +192,30 @@ func main() {
 	if err != nil {
 		_, _ = fmt.Fprintln(output, "error loading program config: ", err, " use default config")
 	} else {
-		programConfig, fatal, other := DDNS.LoadProgramConfig(location)
-		if fatal != nil {
-			// skip setup
-			_, _ = fmt.Fprintln(output, fatal)
-
-		} else {
-			if other != nil {
-				_, _ = fmt.Fprintln(output, other)
+		if DDNS.IsConfigExist(location) {
+			programConfig, fatal, other := DDNS.LoadProgramConfig(location)
+			if fatal != nil {
+				// default setup
+				_, _ = fmt.Fprintln(output, "error loading program config: ", err, " use default config")
+				_, _ = fmt.Fprintln(output, fatal)
+				DDNS.DefaultConfig.Setup()
+			} else {
+				if other != nil {
+					_, _ = fmt.Fprintln(output, other)
+				}
+				programConfig.Setup()
 			}
-			programConfig.Setup()
+		} else {
+			// create Config here
+			_, _ = fmt.Fprintln(output, "no config at ", location, " try to generate a default config")
+			err := DDNS.DefaultConfig.GenerateConfigFile()
+			DDNS.DefaultConfig.Setup()
+			if err != nil {
+				_, _ = fmt.Fprintln(output, "failed to generate default program config at ", location)
+			} else {
+				_, _ = fmt.Fprintln(output, "generate default program config at ", location)
+			}
 		}
-
 	}
 
 	app := &cli.App{


### PR DESCRIPTION
fix: 
create default program config when it doesn't exist 
fix panic out of bound in some case
fix removing service setting in case of bad device setting 
now service will run, using ip set in config, when running with `GodDns run auto override` command

refactor: 
new func DDNS.IsConfigExist replacing DDNS.IsConfigureExist 
move SaveConfig from DDNS package to DDNS.go in main package

test: remove test for func that has been removed